### PR TITLE
options api - immediate watcher handler runs before "created"

* options api - immediate watcher handler runs before "created"

Think this might worth mentioning as recently I introduced and fixed few bugs in a vue app without knowing it.

* Update src/guide/essentials/watchers.md

Co-authored-by: skirtle <65301168+skirtles-code@users.noreply.github.com>

Co-authored-by: skirtle <65301168+skirtles-code@users.noreply.github.com> (#184)

### DIFF
--- a/src/about/team/TeamList.vue
+++ b/src/about/team/TeamList.vue
@@ -61,7 +61,7 @@ defineProps<{
 @media (min-width: 768px) {
   .info {
     position: sticky;
-    top: calc(var(--vt-banner-height) + 32px);
+    top: calc(var(--vt-banner-height, 0px) + 32px);
     left: 0;
     padding: 0 24px 0 0;
     width: 256px;
@@ -74,7 +74,7 @@ defineProps<{
 
 @media (min-width: 960px) {
   .info {
-    top: calc(var(--vt-banner-height) + 88px);
+    top: calc(var(--vt-banner-height, 0px) + 88px);
     padding: 0 64px 0 0;
     width: 384px;
   }

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -244,6 +244,7 @@ export default {
 }
 ```
 
+The initial execution of the handler function will happen just before the `created` hook. Vue will have already processed the `data`, `computed`, and `methods` options, so those properties will be available on the first invocation.
 </div>
 
 <div class="composition-api">


### PR DESCRIPTION
resolves #184
Cherry picked from https://github.com/vuejs/docs/commit/cd32dac7dadc6cacbd7a61dc8131f46c10177dca