### PR TITLE
remove unwanted spaces before links

### DIFF
--- a/src/api/ssr.md
+++ b/src/api/ssr.md
@@ -138,7 +138,7 @@ Effectue le rendu et le transfert à une instance existante d'un [_Writable Stre
 
 - **Exemple :**
 
-  Cette fonction est généralement utilisée en combinaison avec [`TransformStream`] (https://developer.mozilla.org/fr/docs/Web/API/TransformStream) :
+  Cette fonction est généralement utilisée en combinaison avec [`TransformStream`](https://developer.mozilla.org/fr/docs/Web/API/TransformStream) :
 
   ```js
   // TransformStream est disponible dans des environnements tels que les espaces de travail de CloudFlare.

--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -271,7 +271,7 @@ Lorsque les tests End-to-end (E2E) sont exécutés dans des pipelines d'intégra
 
 - [Cypress](https://www.cypress.io/)
 
-  Dans l'ensemble, nous pensons que Cypress fournit la solution E2E la plus complète avec des fonctionnalités telles qu'une interface graphique informative, une excellente déboguabilité, des assertions et des stubs intégrés, une résistance à la "flakiness" des tests, une parallélisation et des instantanés. Comme mentionné ci-dessus, il offre également un support pour [les tests de composants] (https://docs.cypress.io/guides/component-testing/introduction). Cependant, il ne prend en charge que les navigateurs basés sur Chromium et Firefox.
+  Dans l'ensemble, nous pensons que Cypress fournit la solution E2E la plus complète avec des fonctionnalités telles qu'une interface graphique informative, une excellente déboguabilité, des assertions et des stubs intégrés, une résistance à la "flakiness" des tests, une parallélisation et des instantanés. Comme mentionné ci-dessus, il offre également un support pour [les tests de composants](https://docs.cypress.io/guides/component-testing/introduction). Cependant, il ne prend en charge que les navigateurs basés sur Chromium et Firefox.
 
 ### Autres options {#other-options-2}
 

--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -236,7 +236,7 @@ Voir aussi :
 
 Nous pouvons placer cette augmentation de type dans un fichier `.ts`, ou dans un fichier `*.d.ts` à l'échelle du projet. Dans les deux cas, assurez-vous qu'il est inclus dans `tsconfig.json`. Pour les auteurs de bibliothèques / plugins, ce fichier doit être spécifié dans la propriété `types` du `package.json`.
 
-Pour profiter de l'augmentation de module, vous devez vous assurer que l'augmentation est placée dans un [module TypeScript] (https://www.typescriptlang.org/docs/handbook/modules.html). En d'autres termes, le fichier doit contenir au moins un `import` ou un `export` de premier niveau, même s'il s'agit juste d'un `export {}`. Si l'augmentation est placée en dehors d'un module, elle écrasera les types originaux au lieu de les augmenter !
+Pour profiter de l'augmentation de module, vous devez vous assurer que l'augmentation est placée dans un [module TypeScript](https://www.typescriptlang.org/docs/handbook/modules.html). En d'autres termes, le fichier doit contenir au moins un `import` ou un `export` de premier niveau, même s'il s'agit juste d'un `export {}`. Si l'augmentation est placée en dehors d'un module, elle écrasera les types originaux au lieu de les augmenter !
 
 ```ts
 // Ne fonctionne pas, écrase les types d'origine.


### PR DESCRIPTION
J'ai supprimé les espaces qui empêchaient certains liens de fonctionner correctement. Normalement toute la doc est clean sur ce point désormais 👍 