### PR TITLE
fix translation of web components

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -6,7 +6,7 @@ Les composants nous permettent de fractionner l'UI en morceaux indépendants et 
 
 <!-- https://www.figma.com/file/qa7WHDQRWuEZNRs7iZRZSI/components -->
 
-Cette approche est très similaire à celle d'imbriquer des éléments HTML natifs, mais Vue implémente son propre modèle de composant, nous permettant d'encapsuler du contenu et de la logique au sein de chaque composant. Vue fonctionne également bien avec les composants Web natifs. Pour en savoir plus sur la relation entre les composants Vue et les composants Web natifs, [lisez ceci](/guide/extras/web-components.html).
+Cette approche est très similaire à celle d'imbriquer des éléments HTML natifs, mais Vue implémente son propre modèle de composant, nous permettant d'encapsuler du contenu et de la logique au sein de chaque composant. Vue fonctionne également bien avec les Web Components natifs. Pour en savoir plus sur la relation entre les composants Vue et les Web Components natifs, [lisez ceci](/guide/extras/web-components.html).
 
 ## Définir un composant {#defining-a-component}
 

--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -80,7 +80,7 @@ La suite de la documentation présuppose que vous soyez familier avec le HTML, l
 Vue est un framework et un écosystème qui couvre la plupart des fonctionnalités courantes nécessaires au développement front-end. Le Web est très diversifié; les choses que nous y construisons peuvent varier radicalement. C'est pourquoi Vue a été conçu pour être flexible et adoptable de manière incrémentale. En fonction de votre cas d'utilisation, Vue peut être utilisé de différentes manières :
 
 - Extension du HTML statique sans étape de construction
-- Intégration de composants web (custom element) sur n'importe quelle page
+- Intégration de Web Components (éléments personnalisés) sur n'importe quelle page
 - Application mono-page (SPA)
 - Fullstack / Rendu côté serveur (SSR)
 - JAMStack / Génération de sites statiques (SSG)

--- a/src/style-guide/rules-strongly-recommended.md
+++ b/src/style-guide/rules-strongly-recommended.md
@@ -381,7 +381,7 @@ PascalCase a quelques avantages par rapport au kebab-case :
 
 - Les éditeurs peuvent compléter automatiquement les noms de composants dans les templates, car le PascalCase est également utilisé en JavaScript.
 - `<MyComponent>` est visuellement plus distinct d'un élément HTML que `<my-component>`, car il y a deux différences de caractères (les deux majuscules), plutôt qu'une seule (un trait d'union).
-- Si vous utilisez des éléments personnalisés non-Vue dans vos templates, tels qu'un composant Web, le PascalCase garantit que vos composants Vue restent clairement visibles.
+- Si vous utilisez des éléments personnalisés non-Vue dans vos templates, tels qu'un Web Component, le PascalCase garantit que vos composants Vue restent clairement visibles.
 
 Malheureusement, en raison de l'insensibilité à la casse de HTML, les templates du DOM doivent toujours utiliser le kebab-case.
 


### PR DESCRIPTION
Etant donné qu'on garde `web components` au lieu de `composants web`, j'ai corrigé les fois où la traduction avait été faite 👍 