### PR TITLE
fix typo in config.ts

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -51,7 +51,7 @@ const nav: ThemeConfig['nav'] = [
         ]
       },
       {
-        text: 'Libraries Officielles',
+        text: 'Librairies Officielles',
         items: [
           { text: 'Vue Router', link: 'https://router.vuejs.org/' },
           { text: 'Pinia', link: 'https://pinia.vuejs.org/' },


### PR DESCRIPTION
Petite typo, d'ailleurs on garde `librairies` ou `bibliothèques` ?