### PR TITLE
translation of "advanced apis" in config.ts

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -427,7 +427,7 @@ export const sidebar: ThemeConfig['sidebar'] = {
       ]
     },
     {
-      text: 'Advanced APIs',
+      text: 'API avancées',
       items: [
         { text: 'Fonctions de rendu', link: '/api/render-function' },
         { text: 'Rendu côté serveur', link: '/api/ssr' },


### PR DESCRIPTION
Ce titre n'avait pas été traduit, malgré la traduction des pages qui y sont liées.