### PR TITLE
docs: use `npm create` instead of `npm init`

For consistency across package managers.

`yarn` and `pnpm` only support the `create` subcommand.
`init` means something different for them.

So using `create` leads to the least confusion if the user is using
multiple package managers. (#551)

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -24,7 +24,7 @@ Dans cette section, nous allons vous présenter comment créer une [Single Page 
 
 Assurez-vous d'avoir une version à jour de [Node.js](https://nodejs.org/) d'installée et que votre répertoire de travail courant est bien celui où vous souhaitez créer un projet. Exécutez la commande suivante dans votre invite de commandes (sans le symbole `>`) :
 
-<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">&gt;</span> <span style="color:#A6ACCD;">npm init vue@latest</span></span></code></pre></div>
+<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">&gt;</span> <span style="color:#A6ACCD;">npm create vue@latest</span></span></code></pre></div>
 
 Cette commande installera et exécutera [create-vue](https://github.com/vuejs/create-vue), l'outil officiel de création de projets Vue. Des questions (en anglais) vous seront posées pour un certain nombre de fonctionnalités optionnelles telles que la prise en charge de TypeScript et des tests :
 

--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -21,7 +21,7 @@ Il est également recommandé d'utiliser ces terrains de jeu en ligne pour fourn
 
 Pour commencer avec Vite + Vue, exécutez simplement :
 
-<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">$</span> <span style="color:#A6ACCD;">npm init vue@latest</span></span></code></pre></div>
+<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">$</span> <span style="color:#A6ACCD;">npm create vue@latest</span></span></code></pre></div>
 
 Cette commande installera et exécutera [create-vue](https://github.com/vuejs/create-vue), l'outil officiel d'élaboration d'un projet Vue.
 


### PR DESCRIPTION
resolves #551
Cherry picked from https://github.com/vuejs/docs/commit/5c3fd4b6c3caeab2d5c374cf97d467ad26a427ad