### PR TITLE
Update outdated link in template-syntax.md

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -162,7 +162,7 @@ Les fonctions appelées à l'intérieur des expressions de liaison seront appel�
 
 ### Accès global restreint {#restricted-globals-access}
 
-Les expressions de template sont en bac à sable et n'ont accès qu'à une [liste restreinte de variables globales](https://github.com/vuejs/core/blob/main/packages/shared/src/globalsWhitelist.ts#L3). La liste expose les variables globales intégrées couramment utilisées telles que `Math` et `Date`.
+Les expressions de template sont en bac à sable et n'ont accès qu'à une [liste restreinte de variables globales](https://github.com/vuejs/core/blob/main/packages/shared/src/globalsAllowList.ts#L3). La liste expose les variables globales intégrées couramment utilisées telles que `Math` et `Date`.
 
 Les variables globales non explicitement incluses dans la liste, par exemple les propriétés jointes par l'utilisateur sur `window`, ne seront pas accessibles dans les expressions du template. Vous pouvez cependant définir explicitement des variables globales supplémentaires pour toutes les expressions Vue en les ajoutant à [`app.config.globalProperties`](/api/application#app-config-globalproperties).
 


### PR DESCRIPTION
Le lien "liste restreinte de variables globales" du fichier template-syntax.md n'est plus à jour. Cette PR le met à jour.

Closes #604 
     