### PR TITLE
Update built-in-components.md rename <teleport> to <Teleport>

I think teleport component name should be capitalized. Sincere sorry if I'm wrong. (#698)

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -294,17 +294,17 @@ Rend le contenu de son slot à une autre partie du DOM.
   En spécifiant le conteneur cible :
 
   ```vue-html
-  <teleport to="#some-id" />
-  <teleport to=".some-class" />
-  <teleport to="[data-teleport]" />
+  <Teleport to="#some-id" />
+  <Teleport to=".some-class" />
+  <Teleport to="[data-teleport]" />
   ```
 
   En le désactivant de manière conditionnelle :
 
   ```vue-html
-  <teleport to="#popup" :disabled="displayVideoInline">
+  <Teleport to="#popup" :disabled="displayVideoInline">
     <video src="./my-movie.mp4">
-  </teleport>
+  </Teleport>
   ```
 
 - **Voir aussi** [Guide - Teleport](/guide/built-ins/teleport)


### PR DESCRIPTION
resolves #698
Cherry picked from https://github.com/vuejs/docs/commit/7d93d280bb4d014037ab523bad39d5bd5f930caf