### PR TITLE
Removed French documentation link from language select

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -692,11 +692,6 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-uk'
       },
       {
-        link: 'https://fr.vuejs.org',
-        text: 'Français',
-        repo: 'https://github.com/vuejs-translations/docs-fr'
-      },
-      {
         link: 'https://ko.vuejs.org',
         text: '한국어',
         repo: 'https://github.com/vuejs-translations/docs-ko'
@@ -726,7 +721,7 @@ export default defineConfigWithTheme<ThemeConfig>({
     algolia: {
       indexName: 'fr-vuejs',
       appId: 'HH5AXEOM9U',
-      apiKey: 'b33b47187a1497e2a75b99d8a4deee38',
+      apiKey: 'b33b47187a1497e2a75b99d8a4deee38'
     },
 
     carbonAds: {
@@ -757,7 +752,7 @@ export default defineConfigWithTheme<ThemeConfig>({
   markdown: {
     config(md) {
       md.use(headerPlugin)
-        // .use(textAdPlugin)
+      // .use(textAdPlugin)
     }
   },
 


### PR DESCRIPTION
Removed the French documentation link from the language menu since we are already in the French version.

![image](https://github.com/vuejs-translations/docs-fr/assets/109757944/779ca049-8310-4354-a58a-64850aac3cb3)

