### PR TITLE
fix: correctly link to i18n custom blocks (#1161)

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -66,7 +66,7 @@ Des blocs personnalisés supplémentaires peuvent être inclus dans un fichier `
 
 - [Gridsome: `<page-query>`](https://gridsome.org/docs/querying-data/)
 - [vite-plugin-vue-gql: `<gql>`](https://github.com/wheatjs/vite-plugin-vue-gql)
-- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/vite-plugin-vue-i18n#i18n-custom-block)
+- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/unplugin-vue-i18n#i18n-custom-block)
 
 La gestion des blocs personnalisés dépendra des outils utilisés - si vous souhaitez créer vos propres intégrations de blocs personnalisés, consultez [la section dédiée aux outils](/guide/scaling-up/tooling#sfc-custom-block-integrations) pour plus de détails.
 


### PR DESCRIPTION
resolves #1161
Cherry picked from https://github.com/vuejs/docs/commit/7493b263972c078e39db3b3e4b41ac3e01f5f539