### PR TITLE
docs: fix typo in 3.4 example of v-model before defineModel

Update v-model.md (#1317)

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -68,7 +68,7 @@ const emit = defineEmits(['update:modelValue'])
 
 <template>
   <input
-    :value="modelValue"
+    :value="props.modelValue"
     @input="emit('update:modelValue', $event.target.value)"
   />
 </template>
@@ -445,7 +445,7 @@ function emitValue(e) {
 </script>
 
 <template>
-  <input type="text" :value="modelValue" @input="emitValue" />
+  <input type="text" :value="props.modelValue" @input="emitValue" />
 </template>
 ```
 


### PR DESCRIPTION
resolves #1317
Cherry picked from https://github.com/vuejs/docs/commit/6fcf44cf809b6cf51b4c306bfebe531ef96c045d