### PR TITLE
chore(deps): bump @vue/repl from 4.4.2 to 4.4.3

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.4.2 to 4.4.3.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.4.2...v4.4.3)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> (#1524)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@vue/repl':
         specifier: ^4.4.2
-        version: 4.4.2
+        version: 4.4.3
       '@vue/theme':
         specifier: ^2.3.0
         version: 2.3.0(@algolia/client-search@4.23.3)(search-insights@2.14.0)(vitepress@1.5.0(@algolia/client-search@4.23.3)(@types/node@22.7.6)(postcss@8.4.49)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.13(typescript@5.6.3))
@@ -526,8 +526,8 @@ packages:
   '@vue/reactivity@3.5.13':
     resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
 
-  '@vue/repl@4.4.2':
-    resolution: {integrity: sha512-MEAsBK/YzMFGINOBzqM40XTeIYAUsg7CqvXvD5zi0rhYEQrPfEUIdexmMjdm7kVKsKmcvIHxrFK2DFC35m9kHw==}
+  '@vue/repl@4.4.3':
+    resolution: {integrity: sha512-MKIaWgmpaDSfcQrzgsoEFW4jpFbdPYFDn9LBvXFQqEUcosheP9IoUcj/u4omp72oxsecFF5YO4/ssp4aaR8e+g==}
 
   '@vue/runtime-core@3.5.13':
     resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
@@ -1433,7 +1433,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.13
 
-  '@vue/repl@4.4.2': {}
+  '@vue/repl@4.4.3': {}
 
   '@vue/runtime-core@3.5.13':
     dependencies:


### PR DESCRIPTION
resolves #1524
Cherry picked from https://github.com/vuejs/docs/commit/48e2de2e7eb96887e223b2e6ceba894746fb22be