### PR TITLE
Update component-basics.md - wrong highlight about `slot`

Update component-basics.md

In line 471, the line 4 is highlighted but that's wrong and the line 5 must be highlighted that is about `slot`. (#1539)

### DIFF
--- a/src/api/options-lifecycle.md
+++ b/src/api/options-lifecycle.md
@@ -215,6 +215,12 @@ Appelé lorsqu'une erreur venant d'un composant descendant a été capturée.
 
   - Un hook `errorCaptured` peut retourner `false` pour empêcher l'erreur de se propager plus loin. Cela revient à dire "cette erreur a été traitée et doit être ignorée". Cela empêchera tout autre hook `errorCaptured` ou `app.config.errorHandler` d'être invoqué pour cette erreur.
 
+  **Error Capturing Caveats**
+  
+  - In components with async `setup()` function (with top-level `await`) Vue **will always** try to render component template, even if `setup()` throwed error. This will likely cause more errors because during render component's template might try to access non-existing properties of failed `setup()` context. When capturing errors in such components, be ready to handle errors from both failed async `setup()` (they will always come first) and failed render process.
+
+  - <sup class="vt-badge" data-text="SSR only"></sup> Replacing errored child component in parent component deep inside `<Suspense>` will cause hydration mismatches in SSR. Instead, try to separate logic that can possibly throw from child `setup()` into separate function and execute it in the parent component's `setup()`, where you can safely `try/catch` the execution process and make replacement if needed before rendering the actual child component.
+
 ## renderTracked <sup class="vt-badge dev-only" /> {#rendertracked}
 
 Appelé lorsqu'une dépendance réactive a été traquée par l'effet de rendu du composant.

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -468,7 +468,7 @@ Quelque chose de grave s'est produit.
 
 Cela peut être réalisé en utilisant l'élément personnalisé de Vue `<slot>` :
 
-```vue{4}
+```vue{5}
 <!-- AlertBox.vue -->
 <template>
   <div class="alert-box">


### PR DESCRIPTION
resolves #1539
Cherry picked from https://github.com/vuejs/docs/commit/27b5615160b47e1ff5c71ff621db0b2ff34a5462