### PR TITLE
Chore: Update Node.js version requirement in quick start guide

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -23,8 +23,8 @@ import { VTCodeGroup, VTCodeGroupTab } from '@vue/theme'
 :::tip Pré-requis
 
 - Être familier avec l'invite de commandes
-- Avoir installé [Node.js](https://nodejs.org/) version 18.3 ou plus
-  :::
+- Avoir installé [Node.js](https://nodejs.org/) version `^20.19.0 || >=22.12.0`
+:::
 
 Dans cette section, nous allons vous présenter comment créer une [Single Page Application avec Vue](/guide/extras/ways-of-using-vue#single-page-application-spa) sur votre machine locale. Le projet créé utilisera une configuration de build basée sur [Vite](https://vitejs.dev) et nous permettra d'utiliser les [composants monofichiers](/guide/scaling-up/sfc) (SFCs).
 


### PR DESCRIPTION
Changed the Node.js prerequisite in the French quick start guide to require version ^20.19.0 or >=22.12.0 instead of 18.3 or higher, reflecting updated compatibility requirements.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [ ] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [ ] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [ ] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [ ] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
