### PR TITLE
Fix: Add anchor ID to Vnodes heading

### DIFF
--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -208,7 +208,7 @@ function render() {
 }
 ```
 
-### Using Vnodes in `<template>`
+### Using Vnodes in `<template>` {#using-vnodes-in-template}
 
 ```vue
 <script setup>


### PR DESCRIPTION
Add an explicit heading ID ({#using-vnodes-in-template}) to the "Using Vnodes in <template>" section to enable direct linking to that subsection in the render-function guide.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [x] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [x] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [x] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [x] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
