### PR TITLE
fix: use renderAsync for tutorial description syntax highlighting (#1815)

### DIFF
--- a/src/tutorial/tutorial.data.ts
+++ b/src/tutorial/tutorial.data.ts
@@ -15,7 +15,7 @@ export default {
       const stepFiles = files[step]
       const desc = stepFiles['description.md'] as string
       if (desc) {
-        stepFiles['description.md'] = md.render(desc)
+        stepFiles['description.md'] = await md.renderAsync(desc)
       }
     }
     return files


### PR DESCRIPTION
resolves #1815
Cherry picked from https://github.com/vuejs/docs/commit/c8e7b4de586f94be0077bbf88e4f5ec21f4541e2