### PR TITLE
Feat(style-guide): Update style guide examples and links

### DIFF
--- a/src/style-guide/index.md
+++ b/src/style-guide/index.md
@@ -4,11 +4,6 @@ outline: deep
 
 # Bonnes pratiques {#style-guide}
 
-::: warning Note
-Ce guide de style Vue.js est obsolète et doit être revu. Si vous avez des questions ou des suggestions, veuillez [ouvrir une issue](https://github.com/vuejs/docs/issues/new).
-
-:::
-
 Voici le guide de style officiel pour du code spécifique à Vue. Si vous travaillez sur un projet Vue, c'est une super référence pour éviter les erreurs, les pertes de temps, et les anti-patterns. Toutefois, nous ne pensons pas que des bonnes pratiques puisse être idéales pour n'importe quelle équipe ou projet, donc les écarts faits en pleine conscience en fonction de votre expérience, la pile technique environnante, et vos valeurs personnelles sont encouragés.
 
 La plupart du temps, nous évitons également les suggestions à propos du JavaScript ou de l'HTML en général. Que vous utilisiez des points-virgules ou des virgules ne nous dérange pas. Cela ne nous dérange pas non plus que vous utilisiez des simples ou doubles guillemets pour les valeurs des attributs. Il y a cependant des exceptions pour lesquelles nous pensons qu'un pattern particulier peut aider dans le contexte de Vue.

--- a/src/style-guide/rules-essential.md
+++ b/src/style-guide/rules-essential.md
@@ -1,9 +1,5 @@
 # Règles de priorité A : Essentielles {#priority-a-rules-essential}
 
-::: warning Note
-Ce guide de style Vue.js est obsolète et doit être revu. Si vous avez des questions ou des suggestions, veuillez [ouvrir une issue](https://github.com/vuejs/docs/issues/new).
-:::
-
 Ces règles aident à prévenir les erreurs, donc apprenez les et tenez-y vous coûte que coûte. Il peut y avoir des exceptions, mais elles sont rares et devraient être faites par ceux ayant une expertise à la fois dans JavaScript et dans Vue.
 
 ## Utilisez des noms de composants avec plusieurs mots {#use-multi-word-component-names}
@@ -337,7 +333,7 @@ Ou encore, nous pouvons utiliser une balise `<template>` avec `v-for` pour envel
 
 Pour les applications, les styles du composant `App` et des composants de mise en page peuvent être globaux, mais tous les autres styles des composants devraient avoir une portée limitée.
 
-Cela n'est pertinent que pour les [composants monofichiers](/guide/scaling-up/sfc). Cela ne nécessite _pas_ que l'[attribut `scoped`](https://vue-loader.vuejs.org/en/features/scoped-css) soit utilisé. La limitation de la portée peut se faire via des [modules CSS](https://vue-loader.vuejs.org/en/features/css-modules), une stratégie basée sur les classes telle que [BEM](http://getbem.com/), ou tout autre librairie/convention.
+Cela n'est pertinent que pour les [composants monofichiers](/guide/scaling-up/sfc). Cela ne nécessite _pas_ que l'[attribut `scoped`](/api/sfc-css-features#scoped-css) soit utilisé. La limitation de la portée peut se faire via des [modules CSS](/api/sfc-css-features#css-modules), une stratégie basée sur les classes telle que [BEM](https://getbem.com/), ou tout autre librairie/convention.
 
 **Toutefois, pour les librairies de composants, il est préférable d'utiliser une stratégie basée sur les classes au lieu d'utiliser l'attribut `scoped`.**
 

--- a/src/style-guide/rules-recommended.md
+++ b/src/style-guide/rules-recommended.md
@@ -1,9 +1,5 @@
 # Règles de priorité C : Recommandées {#priority-c-rules-recommended}
 
-::: warning Note
-Ce guide de style Vue.js est obsolète et doit être revu. Si vous avez des questions ou des suggestions, veuillez [ouvrir une issue](https://github.com/vuejs/docs/issues/new).
-:::
-
 Lorsqu'il existe plusieurs options correctes, un choix arbitraire peut être fait pour assurer une certaine cohérence. Dans ces règles, nous décrivons chaque option acceptable et suggérons un choix par défaut. Cela signifie que vous être libres de faire un choix différent dans votre code, tant que vous restez cohérent et avez une bonne raison. Vous avez certainement une bonne raison ! En adaptant les standards de la communauté, vous :
 
 1. Entraînerez votre cerveau à analyser plus facilement la plupart du code que vous rencontrerez
@@ -40,6 +36,7 @@ Voici l'ordre par défaut que nous recommandons pour les options d'un composant.
    - `inheritAttrs`
    - `props`
    - `emits`
+   - `expose`
 
 6. **Composition API** (le point d'entrée pour l'utilisation de la Composition API)
 
@@ -67,6 +64,7 @@ Voici l'ordre par défaut que nous recommandons pour les options d'un composant.
      - `errorCaptured`
      - `renderTracked`
      - `renderTriggered`
+     - `serverPrefetch` (SSR seulement)
 
 9. **Propriétés non réactives** (propriétés de l'instance indépendantes du système de réactivité)
 

--- a/src/style-guide/rules-strongly-recommended.md
+++ b/src/style-guide/rules-strongly-recommended.md
@@ -1,9 +1,5 @@
 # Règles de priorité B : Fortement recommandées {#priority-b-rules-strongly-recommended}
 
-::: warning Note
-Ce guide de style Vue.js est obsolète et doit être revu. Si vous avez des questions ou des suggestions, veuillez [ouvrir une issue](https://github.com/vuejs/docs/issues/new).
-:::
-
 Ces règles améliorent la lisibilité et/ou l'expérience des développeurs dans la plupart des projets. Votre code fonctionnera toujours si vous les enfreignez, mais les violations doivent être rares et bien justifiées.
 
 ## Fichiers de composants {#component-files}
@@ -101,23 +97,15 @@ Quelques avantages de cette convention :
 
 - Puisque les noms des composants doivent toujours être des mots composés, cette convention vous fait éviter d'avoir à choisir des préfixes arbitraires pour des composants simples (e.g. MyButton, VueButton).
 
-- Étant donné que ces composants sont fréquemment utilisés, vous pouvez simplement les rendre globaux au lieu de les importer partout. Un préfixe rend cela possible avec Webpack :
+- Étant donné que ces composants sont fréquemment utilisés, vous pouvez simplement les rendre globaux au lieu de les importer partout. Un préfixe rend cela possible avec Vite :
 
   ```js
-  const requireComponent = require.context(
-    './src',
-    true,
-    /Base[A-Z]\w+\.(vue|js)$/
-  )
-  requireComponent.keys().forEach(function (fileName) {
-    let baseComponentConfig = requireComponent(fileName)
-    baseComponentConfig =
-      baseComponentConfig.default || baseComponentConfig
-    const baseComponentName =
-      baseComponentConfig.name ||
-      fileName.replace(/^.+\//, '').replace(/\.\w+$/, '')
-    app.component(baseComponentName, baseComponentConfig)
-  })
+  const modules = import.meta.glob('./src/**/Base*.vue', { eager: true })
+  for (const path in modules) {
+    const config = modules[path].default
+    const name = config.name || path.match(/Base[A-Z]\w+/)[0]
+    app.component(name, config)
+  }
   ```
 
   :::
@@ -317,7 +305,7 @@ components/
 
 Les composants auto-fermants n'indiquent pas seulement qu'ils n'ont pas de contenu, mais aussi qu'ils ne sont pas censés en avoir. C'est la différence entre une page blanche dans un livre et une autre intitulée «Cette page est laissée vierge intentionnellement». Votre code est également plus propre sans la balise de fermeture inutile.
 
-Malheureusement, HTML n'autorise pas que les éléments personnalisés soient auto-fermants - seulement les [éléments officiels "void"](https://www.w3.org/TR/html/syntax.html#void-elements). C'est pourquoi la stratégie n'est possible que lorsque le compilateur de templates de Vue peut atteindre le template avant le DOM, puis servir le HTML conforme aux spécifications.
+Malheureusement, HTML n'autorise pas que les éléments personnalisés soient auto-fermants - seulement les [éléments officiels "void"](https://html.spec.whatwg.org/multipage/syntax.html#void-elements). C'est pourquoi la stratégie n'est possible que lorsque le compilateur de templates de Vue peut atteindre le template avant le DOM, puis servir le HTML conforme aux spécifications.
 
 <div class="style-example style-example-bad">
 <h3>À éviter</h3>

--- a/src/style-guide/rules-use-with-caution.md
+++ b/src/style-guide/rules-use-with-caution.md
@@ -1,9 +1,5 @@
 # Règles de priorité D: À utiliser avec précaution {#priority-d-rules-use-with-caution}
 
-::: warning Note
-Ce guide de style Vue.js est obsolète et doit être revu. Si vous avez des questions ou des suggestions, veuillez [ouvrir une issue](https://github.com/vuejs/docs/issues/new).
-:::
-
 Certaines fonctionnalités de Vue existent pour prévoir de rares cas particuliers ou des migrations plus douces depuis une base de code héritée. Toutefois, lorsqu'elles sont surexploitées, elles peuvent rendre le code plus difficile à maintenir ou même devenir une source de bugs. Ces règles mettent en lumière ces fonctionnalités potentiellement risquées, en décrivant quand et pourquoi elles devraient être évitées.
 
 ## Sélecteurs d'éléments avec `scoped` {#element-selectors-with-scoped}
@@ -179,8 +175,6 @@ defineProps({
 
 ```vue
 <script setup>
-import { getCurrentInstance } from 'vue'
-
 const props = defineProps({
   todo: {
     type: Object,
@@ -188,21 +182,16 @@ const props = defineProps({
   }
 })
 
-const instance = getCurrentInstance()
-
-function removeTodo() {
-  const parent = instance.parent
-  if (!parent) return
-
-  parent.props.todos = parent.props.todos.filter((todo) => {
-    return todo.id !== props.todo.id
-  })
+function renameTodo() {
+  // Modifie l'objet réactif du parent via la prop
+  // En d'autres termes, l'enfant accède à un état appartenant au parent et le modifie.
+  props.todo.text = 'renamed by child'
 }
 </script>
 <template>
   <span>
     {{ todo.text }}
-    <button @click="removeTodo">×</button>
+    <button @click="renameTodo">renommer</button>
   </span>
 </template>
 ```
@@ -231,20 +220,25 @@ const emit = defineEmits(['input'])
 
 ```vue
 <script setup>
-defineProps({
+const props = defineProps({
   todo: {
     type: Object,
     required: true
   }
 })
 
-const emit = defineEmits(['delete'])
+const emit = defineEmits(['update:todo'])
+
+function renameTodo() {
+  // Émet un nouvel objet — le parent est responsable de la mise à jour.
+  emit('update:todo', { ...props.todo, text: 'renamed by parent' })
+}
 </script>
 
 <template>
   <span>
     {{ todo.text }}
-    <button @click="emit('delete')">×</button>
+    <button @click="renameTodo">renommer</button>
   </span>
 </template>
 ```


### PR DESCRIPTION
Remove the outdated deprecation warning from several style-guide pages and modernize content: replace external scoped/css links with internal SFC API anchors, add "expose" and "serverPrefetch" to the component options ordering, swap the require.context Webpack example for an import.meta.glob Vite example, update the void-elements link to the WHATWG HTML spec, and revise component communication examples (remove getCurrentInstance parent mutation example, fix defineProps usage, and show prop mutation vs emitting an update:todo event). These changes modernize examples and correct links across the style-guide files.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [x] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [x] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [x] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [x] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
