### PR TITLE
Fix(vuejsconf): Disable top banner and strip styles

### DIFF
--- a/.vitepress/inlined-scripts/restorePreference.js
+++ b/.vitepress/inlined-scripts/restorePreference.js
@@ -8,6 +8,6 @@
   restore('vue-docs-prefer-composition', 'prefer-composition', true)
   restore('vue-docs-prefer-sfc', 'prefer-sfc', true)
 
-  window.__VUE_BANNER_ID__ = ''
-  restore(`vue-docs-banner-${__VUE_BANNER_ID__}`, 'banner-dismissed')
+  // window.__VUE_BANNER_ID__ = ''
+  // restore(`vue-docs-banner-${__VUE_BANNER_ID__}`, 'banner-dismissed')
 })()

--- a/.vitepress/theme/components/Banner.vue
+++ b/.vitepress/theme/components/Banner.vue
@@ -22,16 +22,7 @@ function dismiss() {
 
 <template>
   <div class="banner" v-if="open">
-    <p class="vt-banner-text">
-      <span class="vt-main">Vueconf 2026</span>
-      <span class="vt-tagline"> · Rejoignez-nous pour tout ce qui concerne <span class="vt-main" style="font-weight: 900;">   Vue + AI </span></span>
-      <span class="vt-place"> · VUE2026 POUR 20 % de réduction !</span>
-      <span class="vt-date"> · Du 19 au 21 mai 2026</span>
-      <a target="_blank" class="vt-primary-action"
-         href="https://vueconf.us//?utm_source=vuejs&utm_content=top_banner">
-        S'inscrire
-      </a>
-    </p>
+    <a target="_blank"></a>
     <button @click="dismiss">
       <VTIconPlus class="close" />
     </button>
@@ -42,7 +33,7 @@ function dismiss() {
 
 <style>
 html:not(.banner-dismissed) {
-  --vt-banner-height: 60px;
+  --vt-banner-height: 30px;
 }
 </style>
 
@@ -59,68 +50,14 @@ html:not(.banner-dismissed) {
   text-align: center;
   font-size: 13px;
   font-weight: 600;
-  color: white;
-  background: #262626;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-}
-
-.glow.glow--purple {
-  position: absolute;
-  bottom: -15%;
-  left: -75%;
-  width: 80%;
-  aspect-ratio: 1.5;
-  pointer-events: none;
-  border-radius: 100%;
-  background: linear-gradient(270deg, #7a23a1, #715ebde6 60% 80%, #bd34fe00);
-  filter: blur(15vw);
-  transform: none;
-  opacity: .6
-}
-
-.glow.glow--blue {
-  position: absolute;
-  bottom: -15%;
-  right: -40%;
-  width: 80%;
-  aspect-ratio: 1.5;
-  pointer-events: none;
-  border-radius: 100%;
-  background: linear-gradient(180deg, #61d9ff, #0000);
-  filter: blur(15vw);
-  transform: none;
-  opacity: .3
-}
-
-@media (min-width: 768px) {
-  .glow.glow--blue {
-    top: -15%;
-    right: -40%;
-    width: 80%;
-  }
-
-  .glow.glow--purple {
-    bottom: -15%;
-    left: -40%;
-    width: 80%;
-  }
-}
-
-@media (min-width: 1025px) {
-  .glow.glow--blue {
-    top: -15%;
-    right: -40%;
-    width: 80%;
-  }
-
-  .glow.glow--purple {
-    bottom: -15%;
-    left: -40%;
-    width: 80%;
-  }
+  color: #fff;
+  background-color: var(--vt-c-green);
+  background: linear-gradient(
+    90deg,
+    rgba(66, 184, 131, 1) 0%,
+    rgba(39, 179, 137, 1) 19%,
+    rgba(100, 126, 255, 1) 100%
+  );
 }
 
 .banner-dismissed .banner {
@@ -135,7 +72,7 @@ button {
   position: absolute;
   right: 0;
   top: 0;
-  padding: 20px 10px;
+  padding: 5px;
 }
 
 .close {
@@ -144,67 +81,10 @@ button {
   fill: #fff;
   transform: rotate(45deg);
 }
-
-.vt-banner-text {
-  color: #fff;
-  font-size: 16px;
-}
-
-.vt-main {
-  color: #42b983;
-  background-clip: text;
-}
-
-.vt-primary-action {
-  background: #42b983;
-  color: #fff;
-  padding: 6px 12px;
-  border-radius: 5px;
-  font-size: 14px;
-  text-decoration: none;
-  margin: 0 20px;
-  font-weight: bold;
-  transition: all;
-  transition-duration: 200ms;
-}
-
-.vt-primary-action:hover {
-  text-decoration: none;
-  transform: translate3d(0, -2px, 0);
-}
-
-@media (max-width: 1280px) {
-  .banner .vt-banner-text {
-    font-size: 14px;
-  }
-
-  .vt-tagline {
+/*
+@media (max-width: 720px) {
+  a > span {
     display: none;
   }
-}
-
-@media (max-width: 780px) {
-  .vt-tagline {
-    display: none;
-  }
-
-  .vt-coupon {
-    display: none;
-  }
-
-  .vt-primary-action {
-    margin: 0 10px;
-    padding: 5px 8px;
-  }
-
-  .vt-time-now {
-    display: none;
-  }
-}
-
-@media (max-width: 560px) {
-  .vt-place {
-    display: none;
-  }
-}
+} */
 </style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -11,7 +11,7 @@ import {
 import SponsorsAside from './components/SponsorsAside.vue'
 import VueSchoolLink from './components/VueSchoolLink.vue'
 import ScrimbaLink from './components/ScrimbaLink.vue'
-import Banner from './components/Banner.vue'
+// import Banner from './components/Banner.vue'
 // import TextAd from './components/TextAd.vue'
 import 'vitepress/dist/client/theme-default/styles/components/vp-code-group.css'
 import 'virtual:group-icons.css'
@@ -20,7 +20,7 @@ export default Object.assign({}, VPTheme, {
   Layout: () => {
     // @ts-ignore
     return h(VPTheme.Layout, null, {
-      banner: () => h(Banner),
+      // banner: () => h(Banner),
       'sidebar-top': () => h(PreferenceSwitch),
       'sidebar-bottom': () => h(SecurityUpdateBtn),
       'aside-mid': () => h(SponsorsAside)


### PR DESCRIPTION
Disable the site-wide promotional banner and remove its markup/styles. Commented out banner preference restoration in .vitepress/inlined-scripts/restorePreference.js, simplified Banner.vue markup (removed promo content) and drastically reduced/changed styling (height, padding, background gradient) while stripping most decorative CSS and responsive rules. Also commented out the Banner import and slot usage in .vitepress/theme/index.ts so the banner is no longer rendered. This effectively disables the banner while keeping the component file for possible future reuse.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [x] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [x] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [x] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [x] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
