### PR TITLE
docs: fix theme description typo

Co-authored-by: Codex <codex@openai.com> (#1836)

### DIFF
--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -266,7 +266,7 @@
       {
         "name": "Free Berry Vuetify VueJs Admin Template",
         "price": 0,
-        "description": "Free & Open Source VueJs Admin Template with well known desing of Berry",
+        "description": "Free & Open Source VueJs Admin Template with well known design of Berry",
         "url": "https://codedthemes.com/item/berry-free-vuetify-vuejs-admin-template/?ref=evan.vuejs",
         "image": "https://org-public-assets.s3.us-west-2.amazonaws.com/Banners/Berry-free-vue.png"
       },

--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -227,10 +227,10 @@ Utiliser [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Access
 
 ![Outils de développeur de Chrome montrant le nom du champs accessible via aria-labelledby](./images/AccessibleARIAlabelledbyDevTools.png)
 
-When this pattern is used inside a reusable component, generate the IDs with
-[`useId()`](/api/composition-api-helpers.html#useid) instead of hard-coding
-them. This keeps each component instance's `id` values unique while still
-linking the visible text to the form control:
+Lorsque ce modèle est utilisé au sein d'un composant réutilisable, générez les identifiants à l'aide de
+[`useId()`](/api/composition-api-helpers.html#useid) au lieu de les coder en dur.
+Cela permet de garantir l'unicité des valeurs `id` de chaque instance de composant tout en
+maintenant le lien entre le texte affiché et le contrôle du formulaire :
 
 ```vue
 <script setup>

--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -227,6 +227,34 @@ Utiliser [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Access
 
 ![Outils de développeur de Chrome montrant le nom du champs accessible via aria-labelledby](./images/AccessibleARIAlabelledbyDevTools.png)
 
+When this pattern is used inside a reusable component, generate the IDs with
+[`useId()`](/api/composition-api-helpers.html#useid) instead of hard-coding
+them. This keeps each component instance's `id` values unique while still
+linking the visible text to the form control:
+
+```vue
+<script setup>
+import { useId } from 'vue'
+
+const sectionId = useId()
+const nameId = useId()
+</script>
+
+<template>
+  <section class="form-section">
+    <h2 :id="sectionId">Billing</h2>
+
+    <label :id="nameId" :for="`${nameId}-input`">Name: </label>
+    <input
+      :id="`${nameId}-input`"
+      type="text"
+      name="name"
+      :aria-labelledby="`${sectionId} ${nameId}`"
+    />
+  </section>
+</template>
+```
+
 #### `aria-describedby` {#aria-describedby}
 
 L'attribut [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) est utilisé de la même manière que `aria-labelledby` à l'exception qu'il fournit une description avec de l'information supplémentaire pour l'utilisateur. Cela peut être utilisé pour décrire le critère pour n'importe quel champ :


### PR DESCRIPTION
resolves #1836
Cherry picked from https://github.com/vuejs/docs/commit/2278428482306ef1fdcf3acbee00fd3a37e9f058