### PR TITLE
Feat(lang): Add German (Deutsch) translation link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -732,6 +732,11 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-uk'
       },
       {
+        link: 'https://de.vuejs.org',
+        text: 'Deutsch',
+        repo: 'https://github.com/vuejs-translations/docs-de'
+      },
+      {
         link: 'https://ko.vuejs.org',
         text: '한국어',
         repo: 'https://github.com/vuejs-translations/docs-ko'

--- a/src/translations/index.md
+++ b/src/translations/index.md
@@ -11,6 +11,7 @@ aside: false
 - [日本語 / Japanese](https://ja.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-ja)]
 - [Українська / Ukrainian](https://ua.vuejs.org) [[source](https://github.com/vuejs-translations/docs-ua)]
 - [Français / French](https://fr.vuejs.org) [[source](https://github.com/vuejs-translations/docs-fr)]
+- [Deutsch / Allemand](https://de.vuejs.org) [[source](https://github.com/vuejs-translations/docs-de)]
 - [한국어 / Korean](https://ko.vuejs.org) [[source](https://github.com/vuejs-translations/docs-ko)]
 - [Português / Portuguese](https://pt.vuejs.org) [[source](https://github.com/vuejs-translations/docs-pt)]
 - [বাংলা / Bengali](https://bn.vuejs.org) [[source](https://github.com/vuejs-translations/docs-bn)]
@@ -25,7 +26,6 @@ aside: false
 
 - [العربية / Arabic](https://ar.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-ar)]
 - [Español / Spanish](https://vue3-spanish-docs.netlify.app/) [[source](https://github.com/icarusgk/vuejs-spanish-docs)]
-- [Deutsch / Allemand](https://de.vuejs.org/) [[source](https://github.com/vuejs-translations/docs-de)]
 
 ## Commencer une nouvelle traduction {#starting-a-new-translation}
 


### PR DESCRIPTION
Include the German docs in the translations list: add a Deutsch entry (link + repo) to .vitepress/config.ts and update src/translations/index.md to add the Deutsch / Allemand link while removing the duplicate entry. This exposes the German site (https://de.vuejs.org) in the site navigation and translations index.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [x] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [x] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [x] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [x] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
