### PR TITLE
Fix: Update Import Map link to WHATWG spec

### DIFF
--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -196,7 +196,7 @@ De plus, pour charger les fichiers client dans le navigateur, nous devons égale
 
 1. Servir les fichiers client en ajoutant `server.use(express.static('.'))` dans `server.js`.
 2. Charger l'entrée client en ajoutant `<script type="module" src="/client.js"></script>` au fichier HTML.
-3. Prendre en charge l'utilisation comme `import * from 'vue'` dans le navigateur en ajoutant [Import Map](https://github.com/WICG/import-maps) au fichier HTML.
+3. Prendre en charge l'utilisation comme `import * from 'vue'` dans le navigateur en ajoutant [Import Map](https://html.spec.whatwg.org/multipage/webappapis.html#import-maps) au fichier HTML.
 
 [Essayez l'exemple complété sur StackBlitz](https://stackblitz.com/fork/vue-ssr-example?file=index.js). Le bouton est maintenant interactif !
 


### PR DESCRIPTION
In src/guide/scaling-up/ssr.md, replace the Import Map link that pointed to the WICG GitHub repo with the canonical WHATWG specification URL. This directs readers to the formal spec for import maps instead of the repository.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [x] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [x] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [x] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [x] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
