### PR TITLE
Docs: document merge behavior for v-bind

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -338,6 +338,30 @@ Sera équivalent à :
 <BlogPost :id="post.id" :title="post.title" />
 ```
 
+### Comportement de fusion lors de la combinaison de liaisons {#merge-behavior-when-combining-bindings}
+
+Lorsque `v-bind` est utilisé en même temps que des liaisons explicites sur le même composant, Vue appelle en interne `mergeProps()` pour les combiner. La stratégie de fusion dépend du type de clé :
+
+- **Props réguliers** — c'est la dernière valeur qui prévaut :
+
+```vue-html
+<!-- title === 'bar' -->
+<BlogPost title="foo" v-bind="{ title: 'bar' }" />
+```
+
+- **Event listeners** — lorsque vous passez des écouteurs dans un objet `v-bind`, [utilisez la convention de clé `onEventName`](/guide/extras/render-function#v-on). Tous les gestionnaires pour le même événement seront appelés (voir [`v-on` Héritage des écouteurs](/guide/components/attrs#v-on-listener-inheritance)) :
+
+```vue-html
+<!-- logs 1 et 2 -->
+<BlogPost @click="console.log(1)" v-bind="{ onClick: () => console.log(2) }" />
+```
+
+- **`class` et `style`** suivent une stratégie de fusion similaire (voir [`class` et `style` Fusion](/guide/components/attrs#class-and-style-merging)).
+
+:::tip
+Les règles de fusion complètes sont décrites dans la référence API de [`mergeProps()`](/api/render-function#mergeprops).
+:::
+
 ## Flux de données à sens unique {#one-way-data-flow}
 
 Tous les props forment une **liaison unidirectionnelle** entre la propriété enfant et la propriété parent : lorsque la propriété parent est mise à jour, elle descendra vers l'enfant, mais pas l'inverse. Cela empêche les composants enfants de muter accidentellement l'état du parent, ce qui peut rendre le flux de données de votre application plus difficile à comprendre.


### PR DESCRIPTION
Add a new section to src/guide/components/props.md explaining how Vue merges explicit props with v-bind (internally via mergeProps()). Covers merge strategies: regular props are last-wins, event listeners (using onEventName keys) are combined so all handlers run, and class/style follow their own merging rules. Includes examples and a pointer to the mergeProps API for full rules.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [x] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [x] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [x] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [x] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
