### PR TITLE
Feat: Update home highlights copy and heading style

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -68,21 +68,21 @@ onMounted(load)
 
   <section id="highlights" class="vt-box-container">
     <div class="vt-box">
-      <h2>Accessible</h2>
-      <p>
-        S’appuie sur les standards HTML, CSS et JavaScript en proposant une API et une documentation traduite en plusieurs langues.
-      </p>
-    </div>
-    <div class="vt-box">
-      <h2>Performant</h2>
-      <p>
-        Se repose sur un système de réactivité, optimisé à la compilation sans devoir y penser par soi-même.
-      </p>
-    </div>
-    <div class="vt-box">
       <h2>Polyvalent</h2>
       <p>
         Un écosystème riche et utilisable progressivement qui peut évoluer selon les besoins, d’une simple librairie à un framework complet.
+      </p>
+    </div>
+    <div class="vt-box">
+      <h2>Convivial</h2>
+      <p>
+        S'appuie sur les standards HTML, CSS et JavaScript en proposant une API intuitive et une documentation de classe mondiale.
+      </p>
+    </div>
+    <div class="vt-box">
+      <h2>Efficace</h2>
+      <p>
+        Un système de rendu réactif et optimisé par le compilateur qui nécessite rarement une optimisation manuelle.
       </p>
     </div>
   </section>
@@ -263,6 +263,10 @@ html:not(.dark) .accent,
 
 #highlights .vt-box {
   background-color: transparent;
+}
+
+#highlights .vt-box h2::first-letter{
+  color: var(--vt-c-green);
 }
 
 #spsrs {


### PR DESCRIPTION
Adjust the headlines and descriptive copy in the highlights section of .vitepress/theme/components/Home.vue to new labels (Polyvalent, Convivial, Efficace) and updated paragraphs to match the messaging. Also add a CSS rule to color the first letter of highlight h2 headings using --vt-c-green for a visual accent.

<!-- IMPORTANT:
  TANT QUE TOUTES LES COCHES NE SONT PAS COCHÉES, la PR ne peut être ouverte, ou alors en Draft.
-->

**Actions à effectuer :**

- [x] Vérifier que le nombre de lignes supprimées égale le nombre de lignes ajoutées
- [x] Mettre en cohérence toute référence à la page traduite qui serait présente sur d'autres pages  
  <!-- Simple recherche du nom du fichier que vous êtes entrain de traduire et vérifier que les titres soient cohérents -->
- [x] Mettre à jour le lien du menu  
  <!-- À effectuer sur .vitepress/config.ts -->
- [x] Lier la PR à une issue  
      Closes # <!-- << Insérer l'id de l'issue -->
      
Remarques:
