### PR TITLE
fix: add self-closing slash to v-model with argument and modifier example (#1860)

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -524,7 +524,7 @@ export default {
 Pour les liens `v-model` avec à la fois un argument et un modificateur, le nom de la prop générée sera `arg + "Modifiers"`. Par exemple :
 
 ```vue-html
-<MyComponent v-model:title.capitalize="myText">
+<MyComponent v-model:title.capitalize="myText" />
 ```
 
 Les déclarations correspondantes doivent être :


### PR DESCRIPTION
resolves #1860
Cherry picked from https://github.com/vuejs/docs/commit/142fa3cc918500c8829c7d0abdd5e3e2ab7a72bc