### PR TITLE
fix: change js to ts code fence for Options API emits TypeScript example (#1862)

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -208,7 +208,7 @@ Plus de détails : [Typer les données émises par les composants](/guide/typesc
 </div>
 <div class="options-api">
 
-```js
+```ts
 export default {
   emits: {
     submit(payload: { email: string, password: string }) {

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -524,7 +524,7 @@ export default {
 Pour les liens `v-model` avec à la fois un argument et un modificateur, le nom de la prop générée sera `arg + "Modifiers"`. Par exemple :
 
 ```vue-html
-<MyComponent v-model:title.capitalize="myText">
+<MyComponent v-model:title.capitalize="myText" />
 ```
 
 Les déclarations correspondantes doivent être :


### PR DESCRIPTION
resolves #1862
Cherry picked from https://github.com/vuejs/docs/commit/c3046b456388d67751f0d71f06950fb468a30310